### PR TITLE
Minor bug fix - one needs to create the capability file if it does not exist

### DIFF
--- a/tasks/write_capability.yml
+++ b/tasks/write_capability.yml
@@ -100,6 +100,7 @@
   win_lineinfile:
     dest: "{{ bambooagent_capability_file }}"
     state: present
+    create: yes
     regexp: "^{{ item.key.strip() | replace('\\n', '') | replace('\\r', '') }}="
     line: >-
        {{ item.key.strip()


### PR DESCRIPTION
Hi @raffienficiaud,
a tiny bug fix in case of a new Windows agent (ansible 2.10).
Cheers!